### PR TITLE
Add clean HSQLDB shutdown and suppress JUL logging noise

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val cpauth = (project in file("."))
 			"com.typesafe.akka"      %% "akka-stream"                        % akkaVersion cross CrossVersion.for3Use2_13,
 			"com.typesafe.akka"      %% "akka-slf4j"                         % akkaVersion cross CrossVersion.for3Use2_13,
 			"ch.qos.logback"         %  "logback-classic"                    % "1.5.16",
+			"org.slf4j"              %  "jul-to-slf4j"                       % "1.7.36",
 			"org.opensaml"           %  "opensaml-saml-impl"                 % "4.3.2",
 			"org.scala-lang.modules" %% "scala-xml"                          % "2.3.0",
 //			"xalan"                  %  "serializer"                         % "2.7.2", //for DOM serialization to strings during debug
@@ -112,6 +113,7 @@ lazy val cpauth = (project in file("."))
 		),
 
 		fork := true,
+		reStart / javaOptions += "-Djava.util.logging.config.file=src/main/resources/logging.properties",
 
 		cpDeployTarget := "cpauth",
 		cpDeployBuildInfoPackage := "se.lu.nateko.cp.cpauth",

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers = org.slf4j.bridge.SLF4JBridgeHandler
+.level = WARNING

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -21,6 +21,7 @@ import eu.icoscp.geoipclient.ErrorEmailer
 import se.lu.nateko.cp.cpauth.routing.PortalLogRouting
 
 import java.sql.DriverManager
+
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
@@ -100,10 +101,16 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 		http.newServerAt(httpConfig.serviceInterface, httpConfig.servicePrivatePort).bindFlow(route)
 	}.onComplete{
 		case Success(binding) =>
-			sys.addShutdownHook{
-				Await.result(binding.unbind(), 3.seconds)
-				println("cpauth has been taken offline successfully")
-			}
+		sys.addShutdownHook{
+			try{
+				val conn = DriverManager.getConnection(config.database.url, config.database.user, config.database.password)
+				try{
+					conn.createStatement().execute("SHUTDOWN")
+				} finally conn.close()
+			} catch case _: Exception => ()
+			Await.result(binding.unbind(), 3.seconds)
+			println("cpauth has been taken offline successfully")
+		}
 			log.info(s"Started cpauth: $binding")
 		case Failure(err) =>
 			log.error(err, "Could not start 'cpauth' service")

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -1,7 +1,9 @@
 package se.lu.nateko.cp.cpauth
 
 import akka.actor.ActorSystem
+import akka.actor.CoordinatedShutdown
 import akka.actor.Scheduler
+import akka.Done
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.*
@@ -22,10 +24,10 @@ import se.lu.nateko.cp.cpauth.routing.PortalLogRouting
 
 import java.sql.DriverManager
 
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.Future
 import scala.util.Failure
+import scala.util.control.NonFatal
 import scala.util.Success
 
 import utils.Utils.getOrCrash
@@ -101,16 +103,25 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 		http.newServerAt(httpConfig.serviceInterface, httpConfig.servicePrivatePort).bindFlow(route)
 	}.onComplete{
 		case Success(binding) =>
-		sys.addShutdownHook{
-			try{
-				val conn = DriverManager.getConnection(config.database.url, config.database.user, config.database.password)
-				try{
-					conn.createStatement().execute("SHUTDOWN")
-				} finally conn.close()
-			} catch case _: Exception => ()
-			Await.result(binding.unbind(), 3.seconds)
-			println("cpauth has been taken offline successfully")
-		}
+			val shutdown = CoordinatedShutdown(system)
+			shutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, "unbind-http-server"){() =>
+				binding.unbind().map(_ => Done)
+			}
+			shutdown.addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "shutdown-user-db"){() =>
+				userDb.shutdown()
+					.map(_ => Done)
+					.recover{
+						case NonFatal(err) =>
+							log.warning(s"Could not shut down embedded DB cleanly: ${err.getMessage}")
+							Done
+					}
+			}
+			shutdown.addTask(CoordinatedShutdown.PhaseActorSystemTerminate, "log-shutdown-complete"){() =>
+				Future.successful{
+					println("cpauth has been taken offline successfully")
+					Done
+				}
+			}
 			log.info(s"Started cpauth: $binding")
 		case Failure(err) =>
 			log.error(err, "Could not start 'cpauth' service")

--- a/src/main/scala/se/lu/nateko/cp/cpauth/accounts/JdbcUsers.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/accounts/JdbcUsers.scala
@@ -26,6 +26,7 @@ trait UsersIo{
 	def userIsAdmin(uid: UserId): Future[Boolean]
 	def setAdminRights(uid: UserId, isAdmin: Boolean): Future[Unit]
 	def init(): Future[Unit]
+	def shutdown(): Future[Unit]
 }
 
 
@@ -33,8 +34,8 @@ class JdbcUsers(getConnection: () => Connection)(using ExecutionContext) extends
 
 	private def execute(statement: String): Future[Unit] = withConnection{ conn =>
 		val st = conn.createStatement
-		st.execute(statement)
-		st.close()
+		try st.execute(statement)
+		finally st.close()
 	}
 
 	private def withConnection[T](work: Connection => T): Future[T] = Future{
@@ -64,6 +65,8 @@ class JdbcUsers(getConnection: () => Connection)(using ExecutionContext) extends
 			isadmin	   boolean default false not null)"""
 		execute(sql)
 	}
+
+	def shutdown(): Future[Unit] = execute("SHUTDOWN")
 
 	def addUser(userEntry: UserEntry, password: String): Future[Unit] = withConnection{ conn =>
 		val ps = conn.prepareStatement("insert into users (mail,password,isadmin) values(?,?,?)")


### PR DESCRIPTION
We were getting the following messages when running `sbt reStart` and this change should fix it:
```
cpauth[ERROR] Feb 27, 2026 9:12:19 AM org.hsqldb.persist.Logger logInfoEvent
cpauth[ERROR] INFO: open start - state modified
cpauth[ERROR] Feb 27, 2026 9:12:19 AM org.hsqldb.persist.Logger logInfoEvent
cpauth[ERROR] INFO: checkpointClose start
cpauth[ERROR] Feb 27, 2026 9:12:19 AM org.hsqldb.persist.Logger logInfoEvent
cpauth[ERROR] INFO: checkpointClose synched
cpauth[ERROR] Feb 27, 2026 9:12:19 AM org.hsqldb.persist.Logger logInfoEvent
cpauth[ERROR] INFO: checkpointClose script done
cpauth[ERROR] Feb 27, 2026 9:12:19 AM org.hsqldb.persist.Logger logInfoEvent
cpauth[ERROR] INFO: checkpointClose end
```