### PR TITLE
Add configuration options for dev/staging/production environments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val viewsCore = (project in file("viewsCore"))
 	.enablePlugins(SbtTwirl)
 	.settings(
 		name := "views-core",
-		version := "0.7.21",
+		version := "0.8.0",
 	)
 
 val akkaVersion = "2.6.19"

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ lazy val viewsCore = (project in file("viewsCore"))
 	.enablePlugins(SbtTwirl)
 	.settings(
 		name := "views-core",
-		version := "0.7.20",
+		version := "0.7.21",
 	)
 
 val akkaVersion = "2.6.19"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -130,9 +130,9 @@ cpauth {
 	mailing.smtpServer = "dummy (replace in proper config)"
 	mailing.password = "dummy (replace in proper config)"
 
-	envSettings {
-		devMode = true
-		# envName = "local"  # Optional: displayed in header. Examples: local, test, staging
+	environment {
+		# name = "local"  # Optional: displayed in header. Examples: local, test, staging
+		showUnderConstruction = true
 		showCarbonBadge = false
 	}
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -130,12 +130,6 @@ cpauth {
 	mailing.smtpServer = "dummy (replace in proper config)"
 	mailing.password = "dummy (replace in proper config)"
 
-	environment {
-		# name = "local"  # Optional: displayed in header. Examples: local, test, staging
-		showUnderConstruction = true
-		showCarbonBadge = false
-	}
-
 	oauth{
 		ICOS: {
 			facebook{
@@ -171,4 +165,5 @@ cpauth {
 			}
 		}
 	}
+
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -130,7 +130,11 @@ cpauth {
 	mailing.smtpServer = "dummy (replace in proper config)"
 	mailing.password = "dummy (replace in proper config)"
 
-	showCarbonBadge = false
+	envSettings {
+		devMode = false
+		# envName = "local"  # Optional: displayed in header. Examples: local, test, staging
+		showCarbonBadge = false
+	}
 
 	oauth{
 		ICOS: {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -130,6 +130,8 @@ cpauth {
 	mailing.smtpServer = "dummy (replace in proper config)"
 	mailing.password = "dummy (replace in proper config)"
 
+	showCarbonBadge = false
+
 	oauth{
 		ICOS: {
 			facebook{

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -131,7 +131,7 @@ cpauth {
 	mailing.password = "dummy (replace in proper config)"
 
 	envSettings {
-		devMode = false
+		devMode = true
 		# envName = "local"  # Optional: displayed in header. Examples: local, test, staging
 		showCarbonBadge = false
 	}

--- a/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
@@ -66,6 +66,12 @@ case class AuthConfig(
 	masterAdminPass: String
 )
 
+case class EnvSettingsConfig(
+	devMode: Boolean,
+	envName: Option[String],
+	showCarbonBadge: Boolean,
+)
+
 case class CpauthConfig(
 	http: HttpConfig,
 	saml: SamlConfig,
@@ -74,7 +80,7 @@ case class CpauthConfig(
 	restheart: RestHeartConfig,
 	mailing: EmailConfig,
 	oauth: CpauthConfig.OAuthConfig,
-	showCarbonBadge: Boolean,
+	envSettings: EnvSettingsConfig,
 )
 
 object CpauthConfig{
@@ -116,5 +122,6 @@ object ConfigReader extends DefaultJsonProtocol:
 	given RootJsonFormat[AuthConfig] = jsonFormat5(AuthConfig.apply)
 	given RootJsonFormat[EmailConfig] = jsonFormat6(EmailConfig.apply)
 	given RootJsonFormat[OAuthProviderConfig] = jsonFormat3(OAuthProviderConfig.apply)
+	given RootJsonFormat[EnvSettingsConfig] = jsonFormat3(EnvSettingsConfig.apply)
 
 	given RootJsonFormat[CpauthConfig] = jsonFormat8(CpauthConfig.apply)

--- a/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
@@ -66,9 +66,9 @@ case class AuthConfig(
 	masterAdminPass: String
 )
 
-case class EnvSettingsConfig(
-	devMode: Boolean,
-	envName: Option[String],
+case class EnvironmentConfig(
+	name: Option[String],
+	showUnderConstruction: Boolean,
 	showCarbonBadge: Boolean,
 )
 
@@ -80,7 +80,7 @@ case class CpauthConfig(
 	restheart: RestHeartConfig,
 	mailing: EmailConfig,
 	oauth: CpauthConfig.OAuthConfig,
-	envSettings: EnvSettingsConfig,
+	environment: EnvironmentConfig,
 )
 
 object CpauthConfig{
@@ -122,6 +122,6 @@ object ConfigReader extends DefaultJsonProtocol:
 	given RootJsonFormat[AuthConfig] = jsonFormat5(AuthConfig.apply)
 	given RootJsonFormat[EmailConfig] = jsonFormat6(EmailConfig.apply)
 	given RootJsonFormat[OAuthProviderConfig] = jsonFormat3(OAuthProviderConfig.apply)
-	given RootJsonFormat[EnvSettingsConfig] = jsonFormat3(EnvSettingsConfig.apply)
+	given RootJsonFormat[EnvironmentConfig] = jsonFormat3(EnvironmentConfig.apply)
 
 	given RootJsonFormat[CpauthConfig] = jsonFormat8(CpauthConfig.apply)

--- a/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
@@ -15,6 +15,7 @@ import scala.util.Try
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.geoipclient.CpGeoConfig
 import se.lu.nateko.cp.cpauth.core.Crypto
+import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
 enum OAuthProvider:
 	case facebook, orcidid, atmoAccess
@@ -64,12 +65,6 @@ case class AuthConfig(
 	secretUserSalt: String,
 	masterAdminUser: String,
 	masterAdminPass: String
-)
-
-case class EnvironmentConfig(
-	name: Option[String],
-	showUnderConstruction: Boolean,
-	showCarbonBadge: Boolean,
 )
 
 case class CpauthConfig(

--- a/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
@@ -15,7 +15,6 @@ import scala.util.Try
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.geoipclient.CpGeoConfig
 import se.lu.nateko.cp.cpauth.core.Crypto
-import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
 enum OAuthProvider:
 	case facebook, orcidid, atmoAccess
@@ -75,7 +74,6 @@ case class CpauthConfig(
 	restheart: RestHeartConfig,
 	mailing: EmailConfig,
 	oauth: CpauthConfig.OAuthConfig,
-	environment: EnvironmentConfig,
 )
 
 object CpauthConfig{
@@ -117,6 +115,5 @@ object ConfigReader extends DefaultJsonProtocol:
 	given RootJsonFormat[AuthConfig] = jsonFormat5(AuthConfig.apply)
 	given RootJsonFormat[EmailConfig] = jsonFormat6(EmailConfig.apply)
 	given RootJsonFormat[OAuthProviderConfig] = jsonFormat3(OAuthProviderConfig.apply)
-	given RootJsonFormat[EnvironmentConfig] = jsonFormat3(EnvironmentConfig.apply)
 
-	given RootJsonFormat[CpauthConfig] = jsonFormat8(CpauthConfig.apply)
+	given RootJsonFormat[CpauthConfig] = jsonFormat7(CpauthConfig.apply)

--- a/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/CpauthConfig.scala
@@ -74,6 +74,7 @@ case class CpauthConfig(
 	restheart: RestHeartConfig,
 	mailing: EmailConfig,
 	oauth: CpauthConfig.OAuthConfig,
+	showCarbonBadge: Boolean,
 )
 
 object CpauthConfig{
@@ -116,4 +117,4 @@ object ConfigReader extends DefaultJsonProtocol:
 	given RootJsonFormat[EmailConfig] = jsonFormat6(EmailConfig.apply)
 	given RootJsonFormat[OAuthProviderConfig] = jsonFormat3(OAuthProviderConfig.apply)
 
-	given RootJsonFormat[CpauthConfig] = jsonFormat7(CpauthConfig.apply)
+	given RootJsonFormat[CpauthConfig] = jsonFormat8(CpauthConfig.apply)

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -39,10 +39,7 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 	given scheduler: Scheduler = system.scheduler
 
 	val config: CpauthConfig = ConfigReader.getDefault.getOrCrash("Problem reading/parsing config file")
-	given environment: EnvironmentConfig = {
-		val es = config.environment
-		EnvironmentConfig(name = es.name, showUnderConstruction = es.showUnderConstruction, showCarbonBadge = es.showCarbonBadge)
-	}
+	given environment: EnvironmentConfig = config.environment
 
 	val (httpConfig, authConfig, samlConfig, oauthConfig) = (config.http, config.auth, config.saml, config.oauth)
 	val http = Http()

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -19,6 +19,7 @@ import se.lu.nateko.cp.cpauth.utils.TargetUrlLookup
 import eu.icoscp.geoipclient.CpGeoClient
 import eu.icoscp.geoipclient.ErrorEmailer
 import se.lu.nateko.cp.cpauth.routing.PortalLogRouting
+import se.lu.nateko.cp.viewscore.{ViewsCoreConfig, viewsCoreConfig as loadedViewsCoreConfig}
 
 import java.sql.DriverManager
 import scala.concurrent.Await
@@ -27,7 +28,6 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 
-import se.lu.nateko.cp.viewscore.EnvironmentConfig
 import utils.Utils.getOrCrash
 
 object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
@@ -39,7 +39,7 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 	given scheduler: Scheduler = system.scheduler
 
 	val config: CpauthConfig = ConfigReader.getDefault.getOrCrash("Problem reading/parsing config file")
-	given environment: EnvironmentConfig = config.environment
+	given viewsCoreConfig: ViewsCoreConfig = loadedViewsCoreConfig
 
 	val (httpConfig, authConfig, samlConfig, oauthConfig) = (config.http, config.auth, config.saml, config.oauth)
 	val http = Http()

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -27,6 +27,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 
+import se.lu.nateko.cp.viewscore.CarbonBadge
 import utils.Utils.getOrCrash
 
 object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
@@ -38,6 +39,7 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 	given scheduler: Scheduler = system.scheduler
 
 	val config: CpauthConfig = ConfigReader.getDefault.getOrCrash("Problem reading/parsing config file")
+	given carbonBadge: CarbonBadge = CarbonBadge(config.showCarbonBadge)
 
 	val (httpConfig, authConfig, samlConfig, oauthConfig) = (config.http, config.auth, config.saml, config.oauth)
 	val http = Http()

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 
-import se.lu.nateko.cp.viewscore.EnvSettings
+import se.lu.nateko.cp.viewscore.EnvironmentConfig
 import utils.Utils.getOrCrash
 
 object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
@@ -39,9 +39,9 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 	given scheduler: Scheduler = system.scheduler
 
 	val config: CpauthConfig = ConfigReader.getDefault.getOrCrash("Problem reading/parsing config file")
-	given envSettings: EnvSettings = {
-		val es = config.envSettings
-		EnvSettings(devMode = es.devMode, envName = es.envName, showCarbonBadge = es.showCarbonBadge)
+	given environment: EnvironmentConfig = {
+		val es = config.environment
+		EnvironmentConfig(name = es.name, showUnderConstruction = es.showUnderConstruction, showCarbonBadge = es.showCarbonBadge)
 	}
 
 	val (httpConfig, authConfig, samlConfig, oauthConfig) = (config.http, config.auth, config.saml, config.oauth)

--- a/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/Main.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 
-import se.lu.nateko.cp.viewscore.CarbonBadge
+import se.lu.nateko.cp.viewscore.EnvSettings
 import utils.Utils.getOrCrash
 
 object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
@@ -39,7 +39,10 @@ object Main extends App with SamlRouting with PasswordRouting with DrupalRouting
 	given scheduler: Scheduler = system.scheduler
 
 	val config: CpauthConfig = ConfigReader.getDefault.getOrCrash("Problem reading/parsing config file")
-	given carbonBadge: CarbonBadge = CarbonBadge(config.showCarbonBadge)
+	given envSettings: EnvSettings = {
+		val es = config.envSettings
+		EnvSettings(devMode = es.devMode, envName = es.envName, showCarbonBadge = es.showCarbonBadge)
+	}
 
 	val (httpConfig, authConfig, samlConfig, oauthConfig) = (config.http, config.auth, config.saml, config.oauth)
 	val http = Http()

--- a/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 
 import SprayJsonSupport.sprayJsValueMarshaller
 import se.lu.nateko.cp.cpauth.core.AnonId
-import se.lu.nateko.cp.viewscore.EnvironmentConfig
+import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
 
 trait CpauthDirectives {
@@ -53,7 +53,7 @@ trait CpauthDirectives {
 
 	given dispatcher: ExecutionContext
 	given scheduler: Scheduler
-	given environment: EnvironmentConfig
+	given viewsCoreConfig: ViewsCoreConfig
 	given ToResponseMarshaller[Html] = TemplatePageMarshalling.marshaller[Html]
 	given [T: RootJsonWriter]: ToEntityMarshaller[T] = SprayJsonSupport.sprayJsonMarshaller
 

--- a/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 
 import SprayJsonSupport.sprayJsValueMarshaller
 import se.lu.nateko.cp.cpauth.core.AnonId
-import se.lu.nateko.cp.viewscore.EnvSettings
+import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
 
 trait CpauthDirectives {
@@ -53,7 +53,7 @@ trait CpauthDirectives {
 
 	given dispatcher: ExecutionContext
 	given scheduler: Scheduler
-	given envSettings: EnvSettings
+	given environment: EnvironmentConfig
 	given ToResponseMarshaller[Html] = TemplatePageMarshalling.marshaller[Html]
 	given [T: RootJsonWriter]: ToEntityMarshaller[T] = SprayJsonSupport.sprayJsonMarshaller
 

--- a/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
@@ -41,6 +41,7 @@ import scala.util.Try
 
 import SprayJsonSupport.sprayJsValueMarshaller
 import se.lu.nateko.cp.cpauth.core.AnonId
+import se.lu.nateko.cp.viewscore.CarbonBadge
 
 
 trait CpauthDirectives {
@@ -52,6 +53,7 @@ trait CpauthDirectives {
 
 	given dispatcher: ExecutionContext
 	given scheduler: Scheduler
+	given carbonBadge: CarbonBadge
 	given ToResponseMarshaller[Html] = TemplatePageMarshalling.marshaller[Html]
 	given [T: RootJsonWriter]: ToEntityMarshaller[T] = SprayJsonSupport.sprayJsonMarshaller
 

--- a/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/routing/CpauthDirectives.scala
@@ -41,7 +41,7 @@ import scala.util.Try
 
 import SprayJsonSupport.sprayJsValueMarshaller
 import se.lu.nateko.cp.cpauth.core.AnonId
-import se.lu.nateko.cp.viewscore.CarbonBadge
+import se.lu.nateko.cp.viewscore.EnvSettings
 
 
 trait CpauthDirectives {
@@ -53,7 +53,7 @@ trait CpauthDirectives {
 
 	given dispatcher: ExecutionContext
 	given scheduler: Scheduler
-	given carbonBadge: CarbonBadge
+	given envSettings: EnvSettings
 	given ToResponseMarshaller[Html] = TemplatePageMarshalling.marshaller[Html]
 	given [T: RootJsonWriter]: ToEntityMarshaller[T] = SprayJsonSupport.sprayJsonMarshaller
 

--- a/src/main/twirl/views/CpauthAdminPage.scala.html
+++ b/src/main/twirl/views/CpauthAdminPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@()(implicit envri: Envri, envSettings: EnvSettings)
+@()(implicit envri: Envri, environment: EnvironmentConfig)
 @CpauthPage(adminPageTitle, "Manage all accounts here", "administration"){
 }{
 	<div class="card mb-4">

--- a/src/main/twirl/views/CpauthAdminPage.scala.html
+++ b/src/main/twirl/views/CpauthAdminPage.scala.html
@@ -1,6 +1,7 @@
 @import eu.icoscp.envri.Envri
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@()(implicit envri: Envri)
+@()(implicit envri: Envri, carbonBadge: CarbonBadge)
 @CpauthPage(adminPageTitle, "Manage all accounts here", "administration"){
 }{
 	<div class="card mb-4">

--- a/src/main/twirl/views/CpauthAdminPage.scala.html
+++ b/src/main/twirl/views/CpauthAdminPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@()(implicit envri: Envri, environment: EnvironmentConfig)
+@()(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @CpauthPage(adminPageTitle, "Manage all accounts here", "administration"){
 }{
 	<div class="card mb-4">

--- a/src/main/twirl/views/CpauthAdminPage.scala.html
+++ b/src/main/twirl/views/CpauthAdminPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@()(implicit envri: Envri, carbonBadge: CarbonBadge)
+@()(implicit envri: Envri, envSettings: EnvSettings)
 @CpauthPage(adminPageTitle, "Manage all accounts here", "administration"){
 }{
 	<div class="card mb-4">

--- a/src/main/twirl/views/CpauthHomePage.scala.html
+++ b/src/main/twirl/views/CpauthHomePage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.homeStrings
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@()(implicit envri: Envri, carbonBadge: CarbonBadge)
+@()(implicit envri: Envri, envSettings: EnvSettings)
 @CpauthPage(homeStrings.title, homeStrings.subheading, "home"){
 }{
 	<div id="hello" style="display: none">

--- a/src/main/twirl/views/CpauthHomePage.scala.html
+++ b/src/main/twirl/views/CpauthHomePage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.homeStrings
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@()(implicit envri: Envri, envSettings: EnvSettings)
+@()(implicit envri: Envri, environment: EnvironmentConfig)
 @CpauthPage(homeStrings.title, homeStrings.subheading, "home"){
 }{
 	<div id="hello" style="display: none">

--- a/src/main/twirl/views/CpauthHomePage.scala.html
+++ b/src/main/twirl/views/CpauthHomePage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.homeStrings
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@()(implicit envri: Envri, environment: EnvironmentConfig)
+@()(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @CpauthPage(homeStrings.title, homeStrings.subheading, "home"){
 }{
 	<div id="hello" style="display: none">
@@ -175,4 +175,3 @@
 		</div>
 	}
 }
-

--- a/src/main/twirl/views/CpauthHomePage.scala.html
+++ b/src/main/twirl/views/CpauthHomePage.scala.html
@@ -1,7 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.homeStrings
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@()(implicit envri: Envri)
+@()(implicit envri: Envri, carbonBadge: CarbonBadge)
 @CpauthPage(homeStrings.title, homeStrings.subheading, "home"){
 }{
 	<div id="hello" style="display: none">

--- a/src/main/twirl/views/CpauthLoginPage.scala.html
+++ b/src/main/twirl/views/CpauthLoginPage.scala.html
@@ -1,7 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.loginStrings
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@(oauthConfigJson: String)(implicit envri: Envri)
+@(oauthConfigJson: String)(implicit envri: Envri, carbonBadge: CarbonBadge)
 @CpauthPage(loginStrings.title, loginStrings.subheading, "login"){
 	<script src="https://static.icos-cp.eu/constant/cookies.js/1.2.1/cookies.min.js"></script>
 	<script src="https://static.icos-cp.eu/constant/jquery/plugins/autocomplete/1.11.4/jquery-ui.min.js"></script>

--- a/src/main/twirl/views/CpauthLoginPage.scala.html
+++ b/src/main/twirl/views/CpauthLoginPage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.loginStrings
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@(oauthConfigJson: String)(implicit envri: Envri, envSettings: EnvSettings)
+@(oauthConfigJson: String)(implicit envri: Envri, environment: EnvironmentConfig)
 @CpauthPage(loginStrings.title, loginStrings.subheading, "login"){
 	<script src="https://static.icos-cp.eu/constant/cookies.js/1.2.1/cookies.min.js"></script>
 	<script src="https://static.icos-cp.eu/constant/jquery/plugins/autocomplete/1.11.4/jquery-ui.min.js"></script>

--- a/src/main/twirl/views/CpauthLoginPage.scala.html
+++ b/src/main/twirl/views/CpauthLoginPage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.loginStrings
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@(oauthConfigJson: String)(implicit envri: Envri, environment: EnvironmentConfig)
+@(oauthConfigJson: String)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @CpauthPage(loginStrings.title, loginStrings.subheading, "login"){
 	<script src="https://static.icos-cp.eu/constant/cookies.js/1.2.1/cookies.min.js"></script>
 	<script src="https://static.icos-cp.eu/constant/jquery/plugins/autocomplete/1.11.4/jquery-ui.min.js"></script>

--- a/src/main/twirl/views/CpauthLoginPage.scala.html
+++ b/src/main/twirl/views/CpauthLoginPage.scala.html
@@ -1,8 +1,8 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.cpauth.views.ViewStrings.loginStrings
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@(oauthConfigJson: String)(implicit envri: Envri, carbonBadge: CarbonBadge)
+@(oauthConfigJson: String)(implicit envri: Envri, envSettings: EnvSettings)
 @CpauthPage(loginStrings.title, loginStrings.subheading, "login"){
 	<script src="https://static.icos-cp.eu/constant/cookies.js/1.2.1/cookies.min.js"></script>
 	<script src="https://static.icos-cp.eu/constant/jquery/plugins/autocomplete/1.11.4/jquery-ui.min.js"></script>

--- a/src/main/twirl/views/CpauthPage.scala.html
+++ b/src/main/twirl/views/CpauthPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
+@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 @template{
 	<script src="https://static.icos-cp.eu/constant/jquery/1.11.2/jquery.min.js"></script>
 	@customHeader

--- a/src/main/twirl/views/CpauthPage.scala.html
+++ b/src/main/twirl/views/CpauthPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @template{
 	<script src="https://static.icos-cp.eu/constant/jquery/1.11.2/jquery.min.js"></script>
 	@customHeader

--- a/src/main/twirl/views/CpauthPage.scala.html
+++ b/src/main/twirl/views/CpauthPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 @template{
 	<script src="https://static.icos-cp.eu/constant/jquery/1.11.2/jquery.min.js"></script>
 	@customHeader

--- a/src/main/twirl/views/CpauthPage.scala.html
+++ b/src/main/twirl/views/CpauthPage.scala.html
@@ -1,6 +1,7 @@
 @import eu.icoscp.envri.Envri
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri)
+@(title: String, subheading: String, scriptName: String)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
 @template{
 	<script src="https://static.icos-cp.eu/constant/jquery/1.11.2/jquery.min.js"></script>
 	@customHeader

--- a/src/main/twirl/views/CpauthPassResetPage.scala.html
+++ b/src/main/twirl/views/CpauthPassResetPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@(email: String)(implicit envri: Envri, environment: EnvironmentConfig)
+@(email: String)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @CpauthPage("Set your password", "Set password", "passwordreset"){
 }{
 	<div class="card">
@@ -35,4 +35,3 @@
 		</div>
 	</div>
 }
-

--- a/src/main/twirl/views/CpauthPassResetPage.scala.html
+++ b/src/main/twirl/views/CpauthPassResetPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@(email: String)(implicit envri: Envri, carbonBadge: CarbonBadge)
+@(email: String)(implicit envri: Envri, envSettings: EnvSettings)
 @CpauthPage("Set your password", "Set password", "passwordreset"){
 }{
 	<div class="card">

--- a/src/main/twirl/views/CpauthPassResetPage.scala.html
+++ b/src/main/twirl/views/CpauthPassResetPage.scala.html
@@ -1,6 +1,7 @@
 @import eu.icoscp.envri.Envri
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@(email: String)(implicit envri: Envri)
+@(email: String)(implicit envri: Envri, carbonBadge: CarbonBadge)
 @CpauthPage("Set your password", "Set password", "passwordreset"){
 }{
 	<div class="card">

--- a/src/main/twirl/views/CpauthPassResetPage.scala.html
+++ b/src/main/twirl/views/CpauthPassResetPage.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@(email: String)(implicit envri: Envri, envSettings: EnvSettings)
+@(email: String)(implicit envri: Envri, environment: EnvironmentConfig)
 @CpauthPage("Set your password", "Set password", "passwordreset"){
 }{
 	<div class="card">

--- a/src/main/twirl/views/CpauthPrivacyStatement.scala.html
+++ b/src/main/twirl/views/CpauthPrivacyStatement.scala.html
@@ -1,6 +1,7 @@
 @import eu.icoscp.envri.Envri
+@import se.lu.nateko.cp.viewscore.CarbonBadge
 
-@()(implicit envri: Envri)
+@()(implicit envri: Envri, carbonBadge: CarbonBadge)
 @template{
 }{
 		<div class="container-fluid">

--- a/src/main/twirl/views/CpauthPrivacyStatement.scala.html
+++ b/src/main/twirl/views/CpauthPrivacyStatement.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@()(implicit envri: Envri, envSettings: EnvSettings)
+@()(implicit envri: Envri, environment: EnvironmentConfig)
 @template{
 }{
 		<div class="container-fluid">

--- a/src/main/twirl/views/CpauthPrivacyStatement.scala.html
+++ b/src/main/twirl/views/CpauthPrivacyStatement.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.CarbonBadge
+@import se.lu.nateko.cp.viewscore.EnvSettings
 
-@()(implicit envri: Envri, carbonBadge: CarbonBadge)
+@()(implicit envri: Envri, envSettings: EnvSettings)
 @template{
 }{
 		<div class="container-fluid">

--- a/src/main/twirl/views/CpauthPrivacyStatement.scala.html
+++ b/src/main/twirl/views/CpauthPrivacyStatement.scala.html
@@ -1,7 +1,7 @@
 @import eu.icoscp.envri.Envri
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@()(implicit envri: Envri, environment: EnvironmentConfig)
+@()(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @template{
 }{
 		<div class="container-fluid">

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -19,8 +19,7 @@ import java.net.URI
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.georestheart.RestHeartDBConfig
 import akka.event.NoLogging
-import se.lu.nateko.cp.cpauth.EnvironmentConfig
-import se.lu.nateko.cp.viewscore.EnvironmentConfig as viewscoreEnvironmentConfig
+import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
 class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 	import Envri.ICOS
@@ -74,7 +73,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
-		val environment = viewscoreEnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false)
+		val environment = EnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -19,6 +19,7 @@ import java.net.URI
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.georestheart.RestHeartDBConfig
 import akka.event.NoLogging
+import se.lu.nateko.cp.viewscore.CarbonBadge
 
 class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 	import Envri.ICOS
@@ -62,6 +63,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		),
 		mailing = null,
 		oauth = null,
+		showCarbonBadge = false,
 	)
 
 	val config = getConfig("src/test/resources/private1.der")
@@ -71,6 +73,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
+		val carbonBadge = CarbonBadge(false)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -19,7 +19,7 @@ import java.net.URI
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.georestheart.RestHeartDBConfig
 import akka.event.NoLogging
-import se.lu.nateko.cp.viewscore.CarbonBadge
+import se.lu.nateko.cp.viewscore.EnvSettings
 
 class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 	import Envri.ICOS
@@ -63,7 +63,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		),
 		mailing = null,
 		oauth = null,
-		showCarbonBadge = false,
+		envSettings = EnvSettingsConfig(devMode = false, envName = None, showCarbonBadge = false),
 	)
 
 	val config = getConfig("src/test/resources/private1.der")
@@ -73,7 +73,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
-		val carbonBadge = CarbonBadge(false)
+		val envSettings = EnvSettings(devMode = false, envName = None, showCarbonBadge = false)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -72,7 +72,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
-		val viewsCoreConfig = ViewsCoreConfig(environmentName = None, showUnderConstruction = false, showCarbonBadge = false, domains = Map.empty)
+		val viewsCoreConfig = ViewsCoreConfig(environmentName = None, showUnderConstruction = false, showCarbonBadge = false, hosts = Map.empty)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -19,7 +19,8 @@ import java.net.URI
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.georestheart.RestHeartDBConfig
 import akka.event.NoLogging
-import se.lu.nateko.cp.viewscore.EnvSettings
+import se.lu.nateko.cp.cpauth.EnvironmentConfig
+import se.lu.nateko.cp.viewscore.EnvironmentConfig as viewscoreEnvironmentConfig
 
 class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 	import Envri.ICOS
@@ -63,7 +64,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		),
 		mailing = null,
 		oauth = null,
-		envSettings = EnvSettingsConfig(devMode = false, envName = None, showCarbonBadge = false),
+		environment = EnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false),
 	)
 
 	val config = getConfig("src/test/resources/private1.der")
@@ -73,7 +74,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
-		val envSettings = EnvSettings(devMode = false, envName = None, showCarbonBadge = false)
+		val environment = viewscoreEnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/cpauth/test/CpauthDirectivesTest.scala
@@ -19,7 +19,7 @@ import java.net.URI
 import eu.icoscp.georestheart.RestHeartConfig
 import eu.icoscp.georestheart.RestHeartDBConfig
 import akka.event.NoLogging
-import se.lu.nateko.cp.viewscore.EnvironmentConfig
+import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
 class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 	import Envri.ICOS
@@ -63,7 +63,6 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		),
 		mailing = null,
 		oauth = null,
-		environment = EnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false),
 	)
 
 	val config = getConfig("src/test/resources/private1.der")
@@ -73,7 +72,7 @@ class CpauthDirectivesTest extends AnyFunSpec with ScalatestRouteTest {
 		val authConfig = config.auth
 		val dispatcher = system.dispatcher
 		val scheduler = system.scheduler
-		val environment = EnvironmentConfig(name = None, showUnderConstruction = false, showCarbonBadge = false)
+		val viewsCoreConfig = ViewsCoreConfig(environmentName = None, showUnderConstruction = false, showCarbonBadge = false, domains = Map.empty)
 		val materializer = Materializer(system)
 		def hostToEnvri(host: String) = config.http.serviceHosts.map(_.swap).get(host)
 		val userDb = null

--- a/viewsCore/src/main/resources/reference.conf
+++ b/viewsCore/src/main/resources/reference.conf
@@ -2,7 +2,7 @@ viewsCore{
 	# environmentName = "local"  # Optional: displayed in header. Examples: local, test, staging
 	showUnderConstruction = false
 	showCarbonBadge = false
-	domains {
+	hosts {
 		ICOS {
 			authHost: ${authPub.ICOS.authHost}
 			dataHost: "datalocal.icos-cp.eu"

--- a/viewsCore/src/main/resources/reference.conf
+++ b/viewsCore/src/main/resources/reference.conf
@@ -1,14 +1,19 @@
 viewsCore{
-	ICOS {
-		authHost: ${authPub.ICOS.authHost}
-		dataHost: "datalocal.icos-cp.eu"
-	}
-	SITES {
-		authHost: ${authPub.SITES.authHost}
-		dataHost: "datalocal.fieldsites.se"
-	}
-	ICOSCities {
-		authHost: ${authPub.ICOSCities.authHost}
-		dataHost: "citydatalocal.icos-cp.eu"
+	# environmentName = "local"  # Optional: displayed in header. Examples: local, test, staging
+	showUnderConstruction = false
+	showCarbonBadge = false
+	domains {
+		ICOS {
+			authHost: ${authPub.ICOS.authHost}
+			dataHost: "datalocal.icos-cp.eu"
+		}
+		SITES {
+			authHost: ${authPub.SITES.authHost}
+			dataHost: "datalocal.fieldsites.se"
+		}
+		ICOSCities {
+			authHost: ${authPub.ICOSCities.authHost}
+			dataHost: "citydatalocal.icos-cp.eu"
+		}
 	}
 }

--- a/viewsCore/src/main/resources/reference.conf
+++ b/viewsCore/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 viewsCore{
 	# environmentName = "local"  # Optional: displayed in header. Examples: local, test, staging
-	showUnderConstruction = false
+	showUnderConstruction = true
 	showCarbonBadge = false
 	hosts {
 		ICOS {

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -8,14 +8,11 @@ import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 
 case class ViewsCoreConfig(authHost: String, dataHost: String)
 
-case class EnvSettings(
-	devMode: Boolean,
-	envName: Option[String],
+case class EnvironmentConfig(
+	showUnderConstruction: Boolean,
+	name: Option[String],
 	showCarbonBadge: Boolean,
 )
-
-object EnvSettings:
-	given EnvSettings = EnvSettings(devMode = false, envName = None, showCarbonBadge = false)
 
 given RootJsonFormat[ViewsCoreConfig] = jsonFormat2(ViewsCoreConfig.apply)
 

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -7,10 +7,15 @@ import se.lu.nateko.cp.cpauth.core.JsonSupport.{given RootJsonFormat[Envri]}
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 
 case class ViewsCoreConfig(authHost: String, dataHost: String)
-case class CarbonBadge(enabled: Boolean)
 
-object CarbonBadge:
-	given CarbonBadge = CarbonBadge(false)
+case class EnvSettings(
+	devMode: Boolean,
+	envName: Option[String],
+	showCarbonBadge: Boolean,
+)
+
+object EnvSettings:
+	given EnvSettings = EnvSettings(devMode = false, envName = None, showCarbonBadge = false)
 
 given RootJsonFormat[ViewsCoreConfig] = jsonFormat2(ViewsCoreConfig.apply)
 

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -6,19 +6,23 @@ import spray.json.RootJsonFormat
 import se.lu.nateko.cp.cpauth.core.JsonSupport.{given RootJsonFormat[Envri]}
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 
-case class ViewsCoreConfig(authHost: String, dataHost: String)
+case class DomainConfig(authHost: String, dataHost: String)
 
-case class EnvironmentConfig(
-	name: Option[String],
+case class ViewsCoreConfig(
+	environmentName: Option[String],
 	showUnderConstruction: Boolean,
 	showCarbonBadge: Boolean,
+	domains: Map[Envri, DomainConfig],
 )
 
-given RootJsonFormat[ViewsCoreConfig] = jsonFormat2(ViewsCoreConfig.apply)
+given RootJsonFormat[DomainConfig] = jsonFormat2(DomainConfig.apply)
+given RootJsonFormat[ViewsCoreConfig] = jsonFormat4(ViewsCoreConfig.apply)
 
-lazy val envri2Config = appConfig.getValue("viewsCore").parseAs[Map[Envri, ViewsCoreConfig]]
+private val viewsCoreConfigRoot = appConfig.getConfig("viewsCore")
 
-def viewsConfig(using envri: Envri) = envri2Config.getOrElse(
+lazy val viewsCoreConfig = viewsCoreConfigRoot.root().parseAs[ViewsCoreConfig]
+
+def domainsConfig(using envri: Envri) = viewsCoreConfig.domains.getOrElse(
 	envri,
 	throw Exception(s"viewscore is not configured for ENVRI '${envri.shortName}'")
 )

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -6,23 +6,23 @@ import spray.json.RootJsonFormat
 import se.lu.nateko.cp.cpauth.core.JsonSupport.{given RootJsonFormat[Envri]}
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 
-case class DomainConfig(authHost: String, dataHost: String)
+case class HostConfig(authHost: String, dataHost: String)
 
 case class ViewsCoreConfig(
 	environmentName: Option[String],
 	showUnderConstruction: Boolean,
 	showCarbonBadge: Boolean,
-	domains: Map[Envri, DomainConfig],
+	hosts: Map[Envri, HostConfig],
 )
 
-given RootJsonFormat[DomainConfig] = jsonFormat2(DomainConfig.apply)
+given RootJsonFormat[HostConfig] = jsonFormat2(HostConfig.apply)
 given RootJsonFormat[ViewsCoreConfig] = jsonFormat4(ViewsCoreConfig.apply)
 
 private val viewsCoreConfigRoot = appConfig.getConfig("viewsCore")
 
 lazy val viewsCoreConfig = viewsCoreConfigRoot.root().parseAs[ViewsCoreConfig]
 
-def domainsConfig(using envri: Envri) = viewsCoreConfig.domains.getOrElse(
+def hostsConfig(using envri: Envri) = viewsCoreConfig.hosts.getOrElse(
 	envri,
 	throw Exception(s"viewscore is not configured for ENVRI '${envri.shortName}'")
 )

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -7,6 +7,10 @@ import se.lu.nateko.cp.cpauth.core.JsonSupport.{given RootJsonFormat[Envri]}
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 
 case class ViewsCoreConfig(authHost: String, dataHost: String)
+case class CarbonBadge(enabled: Boolean)
+
+object CarbonBadge:
+	given CarbonBadge = CarbonBadge(false)
 
 given RootJsonFormat[ViewsCoreConfig] = jsonFormat2(ViewsCoreConfig.apply)
 

--- a/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
+++ b/viewsCore/src/main/scala/se/lu/nateko/cp/viewscore/Config.scala
@@ -9,8 +9,8 @@ import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
 case class ViewsCoreConfig(authHost: String, dataHost: String)
 
 case class EnvironmentConfig(
-	showUnderConstruction: Boolean,
 	name: Option[String],
+	showUnderConstruction: Boolean,
 	showCarbonBadge: Boolean,
 )
 

--- a/viewsCore/src/main/twirl/views/CitiesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CitiesPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 @IcosPage(
 	title,
 	CpMenu.cities,

--- a/viewsCore/src/main/twirl/views/CitiesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CitiesPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @IcosPage(
 	title,
 	CpMenu.cities,

--- a/viewsCore/src/main/twirl/views/CitiesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CitiesPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 @IcosPage(
 	title,
 	CpMenu.cities,

--- a/viewsCore/src/main/twirl/views/CommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CommonPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @template(customHeader)(body)
 
 @template = @{

--- a/viewsCore/src/main/twirl/views/CommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CommonPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 @template(customHeader)(body)
 
 @template = @{

--- a/viewsCore/src/main/twirl/views/CommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CommonPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
 @template(customHeader)(body)
 
 @template = @{

--- a/viewsCore/src/main/twirl/views/CommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CommonPage.scala.html
@@ -4,7 +4,7 @@
 @(
 	title: String,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 @template(customHeader)(body)
 
 @template = @{

--- a/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
@@ -5,11 +5,11 @@
 	title: String,
 	menu: Seq[CpMenuItem] = CpMenu.default,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
 @IcosPage(
   title,
   menu,
   CpStyleConfig,
-  CpFooter(),
+  CpFooter(carbonBadge.enabled),
   bootstrapJavascript,
 )(customHeader)(body)

--- a/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
@@ -5,11 +5,11 @@
 	title: String,
 	menu: Seq[CpMenuItem] = CpMenu.default,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 @IcosPage(
   title,
   menu,
   CpStyleConfig,
-  CpFooter(envSettings.showCarbonBadge),
+  CpFooter(environment.showCarbonBadge),
   bootstrapJavascript,
 )(customHeader)(body)

--- a/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
@@ -5,11 +5,11 @@
 	title: String,
 	menu: Seq[CpMenuItem] = CpMenu.default,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, carbonBadge: CarbonBadge)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 @IcosPage(
   title,
   menu,
   CpStyleConfig,
-  CpFooter(carbonBadge.enabled),
+  CpFooter(envSettings.showCarbonBadge),
   bootstrapJavascript,
 )(customHeader)(body)

--- a/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
+++ b/viewsCore/src/main/twirl/views/CpCommonPage.scala.html
@@ -5,11 +5,11 @@
 	title: String,
 	menu: Seq[CpMenuItem] = CpMenu.default,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 @IcosPage(
-  title,
-  menu,
-  CpStyleConfig,
-  CpFooter(environment.showCarbonBadge),
-  bootstrapJavascript,
+	title,
+	menu,
+	CpStyleConfig,
+	CpFooter(viewsCoreConfig.showCarbonBadge),
+	bootstrapJavascript,
 )(customHeader)(body)

--- a/viewsCore/src/main/twirl/views/CpFooter.scala.html
+++ b/viewsCore/src/main/twirl/views/CpFooter.scala.html
@@ -1,6 +1,6 @@
 @import se.lu.nateko.cp.viewscore.CpMenu.cpHome
 
-@()
+@(showCarbonBadge: Boolean = false)
 <footer id="cp-site-footer" class="site-footer">
 
 	<div class="layout-container">
@@ -16,8 +16,10 @@
 				<p class="marked-link"><a href="@(cpHome)/terms-of-use">TERMS OF USE</a></p>
 				<p class="marked-link"><a href="" data-cc="show-preferencesModal">MANAGE COOKIE PREFERENCES</a></p>
 				<p class="marked-link"><a href="https://uptime.icos-cp.eu/status/core">SERVICES STATUS</a></p>
+				@if(showCarbonBadge) {
 				<div id="wcb" class="carbonbadge text-start mt-4 wcb-d" style="filter: grayscale(1);"></div>
 				<script src="https://unpkg.com/website-carbon-badges@@1.1.3/b.min.js" defer></script>
+				}
 			</div>
 		</div>
 

--- a/viewsCore/src/main/twirl/views/CpFooter.scala.html
+++ b/viewsCore/src/main/twirl/views/CpFooter.scala.html
@@ -1,6 +1,6 @@
 @import se.lu.nateko.cp.viewscore.CpMenu.cpHome
 
-@(showCarbonBadge: Boolean = false)
+@(showCarbonBadge: Boolean)
 <footer id="cp-site-footer" class="site-footer">
 
 	<div class="layout-container">

--- a/viewsCore/src/main/twirl/views/DevMode.scala.html
+++ b/viewsCore/src/main/twirl/views/DevMode.scala.html
@@ -1,0 +1,39 @@
+@import se.lu.nateko.cp.viewscore.EnvSettings
+
+@()(implicit envSettings: EnvSettings)
+@if(envSettings.devMode) {
+<style>
+	.env-border {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 5px;
+		opacity: 0.9;
+		background: repeating-linear-gradient(
+			-45deg,
+			#000,
+			#000 8px,
+			#fc0 8px,
+			#fc0 16px
+		);
+		z-index: 9999;
+	}
+	.header {
+		border-top-width: 5px;
+	}
+	.env-badge {
+		position: fixed;
+		top: 10px;
+		right: 10px;
+		background: #fc0;
+		color: #333;
+		font-size: 11px;
+		font-weight: 600;
+		padding: 1px 8px;
+		border-radius: 3px;
+		opacity: 0.9;
+		z-index: 10000;
+	}
+</style>
+}

--- a/viewsCore/src/main/twirl/views/EnvironmentStyles.scala.html
+++ b/viewsCore/src/main/twirl/views/EnvironmentStyles.scala.html
@@ -1,7 +1,7 @@
-@import se.lu.nateko.cp.viewscore.EnvironmentConfig
+@import se.lu.nateko.cp.viewscore.ViewsCoreConfig
 
-@()(implicit environment: EnvironmentConfig)
-@if(environment.showUnderConstruction) {
+@()(implicit viewsCoreConfig: ViewsCoreConfig)
+@if(viewsCoreConfig.showUnderConstruction) {
 <style>
 	.env-border {
 		position: fixed;

--- a/viewsCore/src/main/twirl/views/EnvironmentStyles.scala.html
+++ b/viewsCore/src/main/twirl/views/EnvironmentStyles.scala.html
@@ -1,7 +1,7 @@
-@import se.lu.nateko.cp.viewscore.EnvSettings
+@import se.lu.nateko.cp.viewscore.EnvironmentConfig
 
-@()(implicit envSettings: EnvSettings)
-@if(envSettings.devMode) {
+@()(implicit environment: EnvironmentConfig)
+@if(environment.showUnderConstruction) {
 <style>
 	.env-border {
 		position: fixed;

--- a/viewsCore/src/main/twirl/views/IcosPage.scala.html
+++ b/viewsCore/src/main/twirl/views/IcosPage.scala.html
@@ -9,7 +9,7 @@
 	styleConf: IcosStyleConfig,
 	footer: Html,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -41,16 +41,49 @@
 
 	@customHeader
 
-	<title>@title | @{envri.shortName}</title>
+	<title>@if(envSettings.devMode){🚧 }@title | @{envri.shortName}</title>
+
+	@if(envSettings.devMode) {
+	<style>
+		.dev-ribbon {
+			background: repeating-linear-gradient(
+				45deg,
+				#000,
+				#000 10px,
+				#fc0 10px,
+				#fc0 20px
+			);
+			color: #000;
+			text-align: center;
+			padding: 4px 0;
+			font-weight: bold;
+			font-size: 14px;
+			position: relative;
+			z-index: 9999;
+		}
+		.dev-ribbon span {
+			background: #fc0;
+			padding: 2px 12px;
+		}
+	</style>
+	}
 
 </head>
 
 <body>
+	@if(envSettings.devMode) {
+	<div class="dev-ribbon"><span>🚧 Development Environment@envSettings.envName.map(n => s" — $n").getOrElse("")</span></div>
+	}
 	<header id="cp-header">
 		<div class="layout-container">
 			<a href=@{styleConf.headerHomeLink} title="Home">
 				<img src=@{styleConf.headerLogo} alt=@{styleConf.headerLogoName}>
 			</a>
+			@for(name <- envSettings.envName) {
+			<div class="d-flex align-items-center ms-3">
+				<span class="badge bg-warning text-dark fs-6">@name</span>
+			</div>
+			}
 			<div class="header-links d-flex align-items-end flex-column justify-content-end pb-5 pe-3">
 				<ul class="d-flex lh-base">
 					<li class="header-link cart-link">

--- a/viewsCore/src/main/twirl/views/IcosPage.scala.html
+++ b/viewsCore/src/main/twirl/views/IcosPage.scala.html
@@ -42,48 +42,22 @@
 	@customHeader
 
 	<title>@if(envSettings.devMode){🚧 }@title | @{envri.shortName}</title>
-
-	@if(envSettings.devMode) {
-	<style>
-		.dev-ribbon {
-			background: repeating-linear-gradient(
-				45deg,
-				#000,
-				#000 10px,
-				#fc0 10px,
-				#fc0 20px
-			);
-			color: #000;
-			text-align: center;
-			padding: 4px 0;
-			font-weight: bold;
-			font-size: 14px;
-			position: relative;
-			z-index: 9999;
-		}
-		.dev-ribbon span {
-			background: #fc0;
-			padding: 2px 12px;
-		}
-	</style>
-	}
+	@DevMode()
 
 </head>
 
 <body>
 	@if(envSettings.devMode) {
-	<div class="dev-ribbon"><span>🚧 Development Environment@envSettings.envName.map(n => s" — $n").getOrElse("")</span></div>
+	<div class="env-border"></div>
+	}
+	@for(name <- envSettings.envName) {
+	<div class="env-badge">@name</div>
 	}
 	<header id="cp-header">
 		<div class="layout-container">
 			<a href=@{styleConf.headerHomeLink} title="Home">
 				<img src=@{styleConf.headerLogo} alt=@{styleConf.headerLogoName}>
 			</a>
-			@for(name <- envSettings.envName) {
-			<div class="d-flex align-items-center ms-3">
-				<span class="badge bg-warning text-dark fs-6">@name</span>
-			</div>
-			}
 			<div class="header-links d-flex align-items-end flex-column justify-content-end pb-5 pe-3">
 				<ul class="d-flex lh-base">
 					<li class="header-link cart-link">

--- a/viewsCore/src/main/twirl/views/IcosPage.scala.html
+++ b/viewsCore/src/main/twirl/views/IcosPage.scala.html
@@ -9,7 +9,7 @@
 	styleConf: IcosStyleConfig,
 	footer: Html,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -41,16 +41,16 @@
 
 	@customHeader
 
-	<title>@if(envSettings.devMode){🚧 }@title | @{envri.shortName}</title>
-	@DevMode()
+	<title>@if(environment.showUnderConstruction){🚧 }@title | @{envri.shortName}</title>
+	@EnvironmentStyles()
 
 </head>
 
 <body>
-	@if(envSettings.devMode) {
+	@if(environment.showUnderConstruction) {
 	<div class="env-border"></div>
 	}
-	@for(name <- envSettings.envName) {
+	@for(name <- environment.name) {
 	<div class="env-badge">@name</div>
 	}
 	<header id="cp-header">

--- a/viewsCore/src/main/twirl/views/IcosPage.scala.html
+++ b/viewsCore/src/main/twirl/views/IcosPage.scala.html
@@ -9,7 +9,7 @@
 	styleConf: IcosStyleConfig,
 	footer: Html,
 	bootstrapJavascript: Boolean = false,
-)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -41,16 +41,16 @@
 
 	@customHeader
 
-	<title>@if(environment.showUnderConstruction){🚧 }@title | @{envri.shortName}</title>
+	<title>@if(viewsCoreConfig.showUnderConstruction){🚧 }@title | @{envri.shortName}</title>
 	@EnvironmentStyles()
 
 </head>
 
 <body>
-	@if(environment.showUnderConstruction) {
+	@if(viewsCoreConfig.showUnderConstruction) {
 	<div class="env-border"></div>
 	}
-	@for(name <- environment.name) {
+	@for(name <- viewsCoreConfig.environmentName) {
 	<div class="env-badge">@name</div>
 	}
 	<header id="cp-header">

--- a/viewsCore/src/main/twirl/views/MainMenuJS.scala.js
+++ b/viewsCore/src/main/twirl/views/MainMenuJS.scala.js
@@ -1,4 +1,4 @@
-@import se.lu.nateko.cp.viewscore.viewsConfig
+@import se.lu.nateko.cp.viewscore.domainsConfig
 @import eu.icoscp.envri.Envri
 
 @()(implicit envri: Envri)
@@ -41,7 +41,7 @@ window.addEventListener("load", function(){
 		if (response.email) {
 			const email = response.email;
 
-			fetch(`https://@(viewsConfig.authHost)/db/users/${email}?keys=${encodeURIComponent('{cart:1}')}`, { credentials: 'include' })
+			fetch(`https://@(domainsConfig.authHost)/db/users/${email}?keys=${encodeURIComponent('{cart:1}')}`, { credentials: 'include' })
 				.then(response => response.json())
 				.then(data => {
 
@@ -49,7 +49,7 @@ window.addEventListener("load", function(){
 					cartLinks.forEach(link => {
 						link.querySelector('.items-number').innerText = data.cart._items.length;
 						link.addEventListener('click', function () {
-							window.location = 'https://@(viewsConfig.dataHost)/portal#{"route":"cart"}';
+						window.location = 'https://@(domainsConfig.dataHost)/portal#{"route":"cart"}';
 						});
 						link.style.display = 'block';
 					});
@@ -57,7 +57,7 @@ window.addEventListener("load", function(){
 					const accountLinks = document.querySelectorAll('.account-link');
 					accountLinks.forEach(link => {
 						link.addEventListener('click', function(){
-							window.location = 'https://@(viewsConfig.authHost)/';
+						window.location = 'https://@(domainsConfig.authHost)/';
 						});
 						link.style.display = 'block';
 					});
@@ -123,7 +123,7 @@ window.addEventListener("load", function(){
 	});
 
 	const updateProfile = (email, data) => {
-		fetch(`https://@(viewsConfig.authHost)/db/users/${email}`, {
+		fetch(`https://@(domainsConfig.authHost)/db/users/${email}`, {
 			credentials: 'include',
 			method: 'PATCH',
 			mode: 'cors',
@@ -135,7 +135,7 @@ window.addEventListener("load", function(){
 	};
 
 	const loginAndRedirect = (url) => {
-		window.location = 'https://@(viewsConfig.authHost)/login/?targetUrl=' + encodeURIComponent(url);
+		window.location = 'https://@(domainsConfig.authHost)/login/?targetUrl=' + encodeURIComponent(url);
 	}
 
 });

--- a/viewsCore/src/main/twirl/views/MainMenuJS.scala.js
+++ b/viewsCore/src/main/twirl/views/MainMenuJS.scala.js
@@ -1,4 +1,4 @@
-@import se.lu.nateko.cp.viewscore.domainsConfig
+@import se.lu.nateko.cp.viewscore.hostsConfig
 @import eu.icoscp.envri.Envri
 
 @()(implicit envri: Envri)
@@ -41,7 +41,7 @@ window.addEventListener("load", function(){
 		if (response.email) {
 			const email = response.email;
 
-			fetch(`https://@(domainsConfig.authHost)/db/users/${email}?keys=${encodeURIComponent('{cart:1}')}`, { credentials: 'include' })
+			fetch(`https://@(hostsConfig.authHost)/db/users/${email}?keys=${encodeURIComponent('{cart:1}')}`, { credentials: 'include' })
 				.then(response => response.json())
 				.then(data => {
 
@@ -49,7 +49,7 @@ window.addEventListener("load", function(){
 					cartLinks.forEach(link => {
 						link.querySelector('.items-number').innerText = data.cart._items.length;
 						link.addEventListener('click', function () {
-						window.location = 'https://@(domainsConfig.dataHost)/portal#{"route":"cart"}';
+						window.location = 'https://@(hostsConfig.dataHost)/portal#{"route":"cart"}';
 						});
 						link.style.display = 'block';
 					});
@@ -57,7 +57,7 @@ window.addEventListener("load", function(){
 					const accountLinks = document.querySelectorAll('.account-link');
 					accountLinks.forEach(link => {
 						link.addEventListener('click', function(){
-						window.location = 'https://@(domainsConfig.authHost)/';
+						window.location = 'https://@(hostsConfig.authHost)/';
 						});
 						link.style.display = 'block';
 					});
@@ -123,7 +123,7 @@ window.addEventListener("load", function(){
 	});
 
 	const updateProfile = (email, data) => {
-		fetch(`https://@(domainsConfig.authHost)/db/users/${email}`, {
+		fetch(`https://@(hostsConfig.authHost)/db/users/${email}`, {
 			credentials: 'include',
 			method: 'PATCH',
 			mode: 'cors',
@@ -135,7 +135,7 @@ window.addEventListener("load", function(){
 	};
 
 	const loginAndRedirect = (url) => {
-		window.location = 'https://@(domainsConfig.authHost)/login/?targetUrl=' + encodeURIComponent(url);
+		window.location = 'https://@(hostsConfig.authHost)/login/?targetUrl=' + encodeURIComponent(url);
 	}
 
 });

--- a/viewsCore/src/main/twirl/views/SitesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/SitesPage.scala.html
@@ -3,7 +3,7 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.viewscore._
 
-@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
+@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -26,16 +26,16 @@
 
 	@customHeader
 
-	<title>@if(envSettings.devMode){🚧 }@title | SITES</title>
-	@DevMode()
+	<title>@if(environment.showUnderConstruction){🚧 }@title | SITES</title>
+	@EnvironmentStyles()
 
 </head>
 
 <body>
-	@if(envSettings.devMode) {
+	@if(environment.showUnderConstruction) {
 	<div class="env-border"></div>
 	}
-	@for(name <- envSettings.envName) {
+	@for(name <- environment.name) {
 	<div class="env-badge">@name</div>
 	}
 	<header class="header layout-container">

--- a/viewsCore/src/main/twirl/views/SitesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/SitesPage.scala.html
@@ -3,7 +3,7 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.viewscore._
 
-@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri, environment: EnvironmentConfig)
+@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri, viewsCoreConfig: ViewsCoreConfig)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -26,16 +26,16 @@
 
 	@customHeader
 
-	<title>@if(environment.showUnderConstruction){🚧 }@title | SITES</title>
+	<title>@if(viewsCoreConfig.showUnderConstruction){🚧 }@title | SITES</title>
 	@EnvironmentStyles()
 
 </head>
 
 <body>
-	@if(environment.showUnderConstruction) {
+	@if(viewsCoreConfig.showUnderConstruction) {
 	<div class="env-border"></div>
 	}
-	@for(name <- environment.name) {
+	@for(name <- viewsCoreConfig.environmentName) {
 	<div class="env-badge">@name</div>
 	}
 	<header class="header layout-container">

--- a/viewsCore/src/main/twirl/views/SitesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/SitesPage.scala.html
@@ -27,37 +27,16 @@
 	@customHeader
 
 	<title>@if(envSettings.devMode){🚧 }@title | SITES</title>
-
-	@if(envSettings.devMode) {
-	<style>
-		.dev-ribbon {
-			background: repeating-linear-gradient(
-				45deg,
-				#000,
-				#000 10px,
-				#fc0 10px,
-				#fc0 20px
-			);
-			color: #000;
-			text-align: center;
-			padding: 4px 0;
-			font-weight: bold;
-			font-size: 14px;
-			position: relative;
-			z-index: 9999;
-		}
-		.dev-ribbon span {
-			background: #fc0;
-			padding: 2px 12px;
-		}
-	</style>
-	}
+	@DevMode()
 
 </head>
 
 <body>
 	@if(envSettings.devMode) {
-	<div class="dev-ribbon"><span>🚧 Development Environment@envSettings.envName.map(n => s" — $n").getOrElse("")</span></div>
+	<div class="env-border"></div>
+	}
+	@for(name <- envSettings.envName) {
+	<div class="env-badge">@name</div>
 	}
 	<header class="header layout-container">
 		<nav class="navbar navbar-expand-lg navbar-dark">
@@ -65,9 +44,6 @@
 				<a href="https://www.fieldsites.se" class="pb-3">
 					<img src="https://static.icos-cp.eu/images/SITES-logo.svg" width=149 height=49 alt="SITES logo">
 				</a>
-				@for(name <- envSettings.envName) {
-				<span class="badge bg-warning text-dark fs-6 ms-3">@name</span>
-				}
 				<button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-menu" aria-controls="offcanvas-menu" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>
 				</button>

--- a/viewsCore/src/main/twirl/views/SitesPage.scala.html
+++ b/viewsCore/src/main/twirl/views/SitesPage.scala.html
@@ -3,7 +3,7 @@
 @import eu.icoscp.envri.Envri
 @import se.lu.nateko.cp.viewscore._
 
-@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri)
+@(title: String)(customHeader: Html)(body: Html)(implicit envri: Envri, envSettings: EnvSettings)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -26,17 +26,48 @@
 
 	@customHeader
 
-	<title>@title | SITES</title>
+	<title>@if(envSettings.devMode){🚧 }@title | SITES</title>
+
+	@if(envSettings.devMode) {
+	<style>
+		.dev-ribbon {
+			background: repeating-linear-gradient(
+				45deg,
+				#000,
+				#000 10px,
+				#fc0 10px,
+				#fc0 20px
+			);
+			color: #000;
+			text-align: center;
+			padding: 4px 0;
+			font-weight: bold;
+			font-size: 14px;
+			position: relative;
+			z-index: 9999;
+		}
+		.dev-ribbon span {
+			background: #fc0;
+			padding: 2px 12px;
+		}
+	</style>
+	}
 
 </head>
 
 <body>
+	@if(envSettings.devMode) {
+	<div class="dev-ribbon"><span>🚧 Development Environment@envSettings.envName.map(n => s" — $n").getOrElse("")</span></div>
+	}
 	<header class="header layout-container">
 		<nav class="navbar navbar-expand-lg navbar-dark">
 			<div class="container-xl">
 				<a href="https://www.fieldsites.se" class="pb-3">
 					<img src="https://static.icos-cp.eu/images/SITES-logo.svg" width=149 height=49 alt="SITES logo">
 				</a>
+				@for(name <- envSettings.envName) {
+				<span class="badge bg-warning text-dark fs-6 ms-3">@name</span>
+				}
 				<button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-menu" aria-controls="offcanvas-menu" aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>
 				</button>


### PR DESCRIPTION
## Update

I moved the configuration to the `viewsCore` property. This should be a better setup as these configuration options are for the `viewsCore` project and not directly for `cpauth`. Unfortunately the `viewsCore` property was used to store a `Map[Envri, ViewsCoreConfig]` which I moved to `viewsCore.domains`. This is a breaking change and will require previous configurations to be updated following the format in `viewsCore/src/main/resources/reference.conf`. The updated configuration is then:
```
viewsCore {
	# environmentName = "local"  # Optional: displayed in header. Examples: local, test, staging
	showUnderConstruction = true
	showCarbonBadge = false
	hosts { ... }
}
```

## Original description

Add `environment` property in `application.conf` with the following keys:
- `name` is an optional string. It displays the name of the environment in a badge at the top right of pages. It's empty and hidden by default.
- `showUnderConstruction` is a boolean. When true, it shows a 🚧 in the title tag, and a yellow and black banner at the top of pages. It is true by default and should be set to false in production configurations.
- `showCarbonBadge` is a boolean. When true, it shows a carbon badge in the page footer. It is false and hidden by default to avoid errors in the console in local environment. It should be set to true in production configurations.
```
environment {
	# name = "local"  # Optional: displayed in header. Examples: local, test, staging
	showUnderConstruction = true
	showCarbonBadge = false
}
```
Our other projects like meta, data, and doi will be able to use this config the same way cpauth does it here.

With `showUnderConstruction` set to `true` and `name` to `local`, the header would like:

![under-construction](https://github.com/user-attachments/assets/249b9584-2bcb-4d2b-968e-e36ef3b0fe87)
