### PR TITLE
Don't request PPT auth context class

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/cpauth/utils/Saml.scala
+++ b/src/main/scala/se/lu/nateko/cp/cpauth/utils/Saml.scala
@@ -35,12 +35,6 @@ object Saml {
 
 			<samlp:NameIDPolicy Format={NameIDType.TRANSIENT} AllowCreate="true"/>
 
-			<samlp:RequestedAuthnContext Comparison="exact">
-				<saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
-					urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
-				</saml:AuthnContextClassRef>
-			</samlp:RequestedAuthnContext>
-
 		</samlp:AuthnRequest>
 		(xml, id)
 	}


### PR DESCRIPTION
Section 3.4.9 PasswordProtectedTransport from the OASIS [SAML Authentication Context specification](https://docs.oasis-open.org/security/saml/v2.0/saml-authn-context-2.0-os.pdf):

> The PasswordProtectedTransport class is applicable when a principal authenticates to an authentication authority through the presentation of a password over a protected session.

By specifically requesting (`Comparison="exact"`) this auth context class from any IDP (as was done here in code this PR now removes), you're actually asking the IDP to authenticate the subject using the weakest possible authentication method still widely deployed: Clear text passwords sent over TLS. There is simply no reason to do that. The only thing this would be an improvement over would be hypothetical use of `urn:oasis:names:tc:SAML:2.0:ac:classes:Password`, cf. section 3.4.8 Password of that spec:

> The Password class is applicable when a principal authenticates to an authentication authority through the presentation of a password over an unprotected HTTP session.

Which noone would use for an authentication service (SAML IDP), at least not in the last 30 years or so. So, with `Password` out of the way, the only thing the current implementation achieves, is weakening security by preventing use of stronger authentication methods at the IDP. (Essentially anything else an IDP would offer today will be stronger than cleartext passwords over TLS.)